### PR TITLE
Adds show hide option to text

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -11,10 +11,7 @@
             "xwalk": {
               "page": {
                 "resourceType": "core/franklin/components/text/v1/text",
-                "template": {
-                  "name": "Text",
-                  "model": "text"
-                }
+                "template": {}
               }
             }
           }

--- a/component-definition.json
+++ b/component-definition.json
@@ -11,7 +11,10 @@
             "xwalk": {
               "page": {
                 "resourceType": "core/franklin/components/text/v1/text",
-                "template": {}
+                "template": {
+                  "name": "Text",
+                  "model": "text"
+                }
               }
             }
           }

--- a/component-models.json
+++ b/component-models.json
@@ -243,5 +243,27 @@
         "description": "Please provide a URL to an MPC video."
       }
     ]
+  },
+  {
+    "id": "text",
+    "fields": [
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "display",
+        "label": "Display Text",
+        "value": "show",
+        "options": [
+          {
+            "name": "Show",
+            "value": "show"
+          },
+          {
+            "name": "Hide",
+            "value": "hide"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/component-models.json
+++ b/component-models.json
@@ -57,23 +57,6 @@
             "value": "h6"
           }
         ]
-      },
-      {
-        "component": "select",
-        "valueType": "string",
-        "name": "display",
-        "label": "Display Text",
-        "value": "show",
-        "options": [
-          {
-            "name": "Show",
-            "value": "show"
-          },
-          {
-            "name": "Hide",
-            "value": "hide"
-          }
-        ]
       }
     ]
   },

--- a/component-models.json
+++ b/component-models.json
@@ -57,6 +57,23 @@
             "value": "h6"
           }
         ]
+      },
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "display",
+        "label": "Display Text",
+        "value": "show",
+        "options": [
+          {
+            "name": "Show",
+            "value": "show"
+          },
+          {
+            "name": "Hide",
+            "value": "hide"
+          }
+        ]
       }
     ]
   },

--- a/component-models.json
+++ b/component-models.json
@@ -248,6 +248,13 @@
     "id": "text",
     "fields": [
       {
+        "component": "text-area",
+        "valueType": "string",
+        "name": "text",
+        "value": "",
+        "label": "Richtext"
+      },
+      {
         "component": "select",
         "valueType": "string",
         "name": "display",


### PR DESCRIPTION
This PR adds a show hide display option to the text component while maintaining the existing text area richtext field.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.hlx.page/
- After: https://<branch>--{repo}--{owner}.hlx.page/
